### PR TITLE
Use short hash in generated labels

### DIFF
--- a/.changeset/young-llamas-grow.md
+++ b/.changeset/young-llamas-grow.md
@@ -1,0 +1,5 @@
+---
+'@svitejs/changesets-changelog-github-compact': minor
+---
+
+Use short hash in generated labels for same repo commits

--- a/packages/changesets-changelog-github-compact/package.json
+++ b/packages/changesets-changelog-github-compact/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/svitejs/changesets-changelog-github-compact#readme",
   "dependencies": {
-    "@changesets/get-github-info": "^0.5.2",
+    "@changesets/get-github-info": "^0.6.0",
     "dotenv": "^16.0.3"
   },
   "devDependencies": {

--- a/packages/changesets-changelog-github-compact/src/index.ts
+++ b/packages/changesets-changelog-github-compact/src/index.ts
@@ -77,7 +77,10 @@ const changelogFunctions: ChangelogFunctions = {
 				if (commitFromSummary) {
 					links = {
 						...links,
-						commit: `[\`${commitFromSummary}\`](https://github.com/${repo}/commit/${commitFromSummary})`
+						commit: `[\`${commitFromSummary.slice(
+							0,
+							7
+						)}\`](https://github.com/${repo}/commit/${commitFromSummary})`
 					};
 				}
 				return links;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
   packages/changesets-changelog-github-compact:
     dependencies:
       '@changesets/get-github-info':
-        specifier: ^0.5.2
-        version: 0.5.2
+        specifier: ^0.6.0
+        version: 0.6.0
       dotenv:
         specifier: ^16.0.3
         version: 16.3.1
@@ -220,8 +220,8 @@ packages:
       semver: 7.5.4
     dev: true
 
-  /@changesets/get-github-info@0.5.2:
-    resolution: {integrity: sha512-JppheLu7S114aEs157fOZDjFqUDpm7eHdq5E8SSR0gUBTEK0cNSHsrSR5a66xs0z3RWuo46QvA3vawp8BxDHvg==}
+  /@changesets/get-github-info@0.6.0:
+    resolution: {integrity: sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==}
     dependencies:
       dataloader: 1.4.0
       node-fetch: 2.7.0


### PR DESCRIPTION
- [x] Updated `@changesets/get-github-info` to `0.6.0`
- [x] Slice hash label only for commits of the same repository. Generated URL's use the full hash